### PR TITLE
Prevent segfault while scanning for MP3 files

### DIFF
--- a/pico/cd/cd_image.c
+++ b/pico/cd/cd_image.c
@@ -61,6 +61,7 @@ static void to_upper(char *d, const char *s)
     else
       *d = *s;
   }
+  *d = 0;
 }
 
 // cdd.c uses lba - 150


### PR DESCRIPTION
Make sure the destination string is NULL-terminated when building the uppercase extension in to_upper. The tmp_ext_u array is uninitialized when it's passed to this function.
