### PR TITLE
Add core option to force the Region FPS (NTSC, PAL)

### DIFF
--- a/pico/media.c
+++ b/pico/media.c
@@ -244,7 +244,7 @@ enum media_type_e PicoLoadMedia(const char *filename,
 
   rom = pm_open(rom_fname);
   if (rom == NULL) {
-    lprintf("Failed to open ROM");
+    lprintf("Failed to open ROM\n");
     media_type = PM_ERROR;
     goto out;
   }
@@ -252,9 +252,9 @@ enum media_type_e PicoLoadMedia(const char *filename,
   ret = PicoCartLoad(rom, &rom_data, &rom_size, (PicoAHW & PAHW_SMS) ? 1 : 0);
   pm_close(rom);
   if (ret != 0) {
-    if      (ret == 2) lprintf("Out of memory");
-    else if (ret == 3) lprintf("Read failed");
-    else               lprintf("PicoCartLoad() failed.");
+    if      (ret == 2) lprintf("Out of memory\n");
+    else if (ret == 3) lprintf("Read failed\n");
+    else               lprintf("PicoCartLoad() failed.\n");
     media_type = PM_ERROR;
     goto out;
   }

--- a/pico/pico.h
+++ b/pico/pico.h
@@ -81,9 +81,10 @@ extern int PicoAHW;            // Pico active hw
 #define PQUIRK_FORCE_6BTN   (1<<0)
 extern int PicoQuirks;
 
-extern int PicoSkipFrame;      // skip rendering frame, but still do sound (if enabled) and emulation stuff
-extern int PicoRegionOverride; // override the region detection 0: auto, 1: Japan NTSC, 2: Japan PAL, 4: US, 8: Europe
-extern int PicoAutoRgnOrder;   // packed priority list of regions, for example 0x148 means this detection order: EUR, USA, JAP
+extern int PicoSkipFrame;         // skip rendering frame, but still do sound (if enabled) and emulation stuff
+extern int PicoRegionOverride;    // override the region detection 0: auto, 1: Japan NTSC, 2: Japan PAL, 4: US, 8: Europe
+extern int PicoRegionFPSOverride; // override the refresh rate of the region 0: Auto, 1: NTSC, 2: PAL
+extern int PicoAutoRgnOrder;      // packed priority list of regions, for example 0x148 means this detection order: EUR, USA, JAP
 extern int PicoSVPCycles;
 void PicoInit(void);
 void PicoExit(void);

--- a/pico/sound/sound.c
+++ b/pico/sound/sound.c
@@ -118,6 +118,10 @@ PICO_INTERNAL void PsndReset(void)
 // to be called after changing sound rate or chips
 void PsndRerate(int preserve_state)
 {
+  // PsndRerate not ready yet
+  if (Pico.romsize <= 0)
+    return;
+
   void *state = NULL;
   int target_fps = Pico.m.pal ? 50 : 60;
 

--- a/platform/libretro/libretro.c
+++ b/platform/libretro/libretro.c
@@ -477,12 +477,12 @@ void lprintf(const char *fmt, ...)
 void retro_set_environment(retro_environment_t cb)
 {
    static const struct retro_variable vars[] = {
-      //{ "region", "Region; Auto|NTSC|PAL" },
-      { "picodrive_input1", "Input device 1; 3 button pad|6 button pad|None" },
-      { "picodrive_input2", "Input device 2; 3 button pad|6 button pad|None" },
-      { "picodrive_sprlim", "No sprite limit; disabled|enabled" },
-      { "picodrive_ramcart", "MegaCD RAM cart; disabled|enabled" },
-      { "picodrive_region", "Region; Auto|Japan NTSC|Japan PAL|US|Europe" },
+      { "picodrive_input1",      "Input device 1; 3 button pad|6 button pad|None" },
+      { "picodrive_input2",      "Input device 2; 3 button pad|6 button pad|None" },
+      { "picodrive_sprlim",      "No sprite limit; disabled|enabled" },
+      { "picodrive_ramcart",     "MegaCD RAM cart; disabled|enabled" },
+      { "picodrive_region",      "Region; Auto|Japan NTSC|Japan PAL|US|Europe" },
+      { "picodrive_region_fps",  "Region FPS; Auto|NTSC|PAL"},
 #ifdef DRC_SH2
       { "picodrive_drc", "Dynamic recompilers; enabled|disabled" },
 #endif
@@ -1144,6 +1144,7 @@ static void update_variables(void)
          PicoOpt &= ~POPT_EN_MCD_RAMCART;
    }
 
+   int OldPicoRegionOverride = PicoRegionOverride;
    var.value = NULL;
    var.key = "picodrive_region";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
@@ -1159,6 +1160,27 @@ static void update_variables(void)
          PicoRegionOverride = 8;
    }
 
+   int OldPicoRegionFPSOverride = PicoRegionFPSOverride;
+   var.value = NULL;
+   var.key = "picodrive_region_fps";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
+      if (strcmp(var.value, "Auto") == 0)
+         PicoRegionFPSOverride = 0;
+      else if (strcmp(var.value, "NTSC") == 0)
+         PicoRegionFPSOverride = 1;
+      else if (strcmp(var.value, "PAL") == 0)
+         PicoRegionFPSOverride = 2;         
+   }
+   
+   // Update region, fps and sound flags if needed
+   if (PicoRegionOverride    != OldPicoRegionOverride ||
+       PicoRegionFPSOverride != OldPicoRegionFPSOverride)
+   {
+      PicoDetectRegion();
+      PicoLoopPrepare();
+      PsndRerate(1);
+   }
+      
 #ifdef DRC_SH2
    var.value = NULL;
    var.key = "picodrive_drc";

--- a/platform/libretro/libretro.c
+++ b/platform/libretro/libretro.c
@@ -469,7 +469,7 @@ void lprintf(const char *fmt, ...)
    vsprintf(buffer, fmt, ap);
    /* TODO - add 'level' param for warning/error messages? */
    if (log_cb)
-      log_cb(RETRO_LOG_INFO, "%s\n", fmt, ap);
+      log_cb(RETRO_LOG_INFO, "%s", buffer);
    va_end(ap);
 }
 


### PR DESCRIPTION
This new core option will override the Region option.
So it's possible to choose the Europe Region and the NTSC FPS.
Strangely the region protection has no effect on megadrive :-)
But will happend on 32x and SegaCD (Maybe it can be fixed by activating
this core option after a little delay on startup)