### PR TITLE
Fix compilation with DEBUG flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,18 @@
 TARGET ?= PicoDrive
+DEBUG = 0
 CFLAGS += -Wall 
 CFLAGS += -I. -DINLINE=inline
-ifndef DEBUG
+ifeq ($(DEBUG),0)
 ifeq ($(platform), vita)
 CFLAGS += -O3 -DNDEBUG
 else
 CFLAGS += -O2 -DNDEBUG -ffunction-sections
 endif
+else
+CFLAGS += -g -O2
+endif
 ifneq ($(APPLE),1)
 LDFLAGS += -Wl,--gc-sections
-endif
 endif
 #CFLAGS += -DEVT_LOG
 #CFLAGS += -DDRC_CMP


### PR DESCRIPTION
- Use DEBUG flag similar to other libretro cores (DEBUG=0 disables, DEBUG=1 enables the debug build)
- Optimize with -O2 for debugging because the core won't work otherwise
- Always strip sections to prevent undefined symbol errors

See https://github.com/libretro/picodrive/issues/29