### PR TITLE
Check if DEBUG is set rather than not set.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,18 +2,21 @@ TARGET ?= PicoDrive
 DEBUG = 0
 CFLAGS += -Wall 
 CFLAGS += -I. -DINLINE=inline
-ifeq ($(DEBUG),0)
-ifeq ($(platform), vita)
-CFLAGS += -O3 -DNDEBUG
+
+ifeq ($(DEBUG),1)
+	CFLAGS += -g -O0
 else
-CFLAGS += -O2 -DNDEBUG -ffunction-sections
+	ifeq ($(platform), vita)
+		CFLAGS += -O3 -DNDEBUG
+	else
+		CFLAGS += -O2 -DNDEBUG -ffunction-sections
+	endif
 endif
-else
-CFLAGS += -g -O2
-endif
+
 ifneq ($(APPLE),1)
-LDFLAGS += -Wl,--gc-sections
+	LDFLAGS += -Wl,--gc-sections
 endif
+
 #CFLAGS += -DEVT_LOG
 #CFLAGS += -DDRC_CMP
 #cpu_cmp = 1
@@ -23,7 +26,6 @@ endif
 ifeq ($(WANT_GDB),1)
 CFLAGS += ggdb -falign-functions=2
 endif
-
 
 all: config.mak target_
 

--- a/pico/sound/ym2612.c
+++ b/pico/sound/ym2612.c
@@ -535,7 +535,7 @@ static int g_lfo_ampm = 0;
 
 
 /* OPN Mode Register Write */
-INLINE void set_timers( int v )
+static INLINE void set_timers( int v )
 {
 	/* b7 = CSM MODE */
 	/* b6 = 3 slot mode */
@@ -590,13 +590,13 @@ INLINE void set_det_mul(FM_CH *CH, FM_SLOT *SLOT, int v)
 }
 
 /* set total level */
-INLINE void set_tl(FM_SLOT *SLOT, int v)
+static INLINE void set_tl(FM_SLOT *SLOT, int v)
 {
 	SLOT->tl = (v&0x7f)<<(ENV_BITS-7); /* 7bit TL */
 }
 
 /* set attack rate & key scale  */
-INLINE void set_ar_ksr(FM_CH *CH, FM_SLOT *SLOT, int v)
+static INLINE void set_ar_ksr(FM_CH *CH, FM_SLOT *SLOT, int v)
 {
 	UINT8 old_KSR = SLOT->KSR;
 
@@ -628,7 +628,7 @@ INLINE void set_ar_ksr(FM_CH *CH, FM_SLOT *SLOT, int v)
 }
 
 /* set decay rate */
-INLINE void set_dr(FM_SLOT *SLOT, int v)
+static INLINE void set_dr(FM_SLOT *SLOT, int v)
 {
 	int eg_sh_d1r, eg_sel_d1r;
 
@@ -641,7 +641,7 @@ INLINE void set_dr(FM_SLOT *SLOT, int v)
 }
 
 /* set sustain rate */
-INLINE void set_sr(FM_SLOT *SLOT, int v)
+static INLINE void set_sr(FM_SLOT *SLOT, int v)
 {
 	int eg_sh_d2r, eg_sel_d2r;
 
@@ -654,7 +654,7 @@ INLINE void set_sr(FM_SLOT *SLOT, int v)
 }
 
 /* set release rate */
-INLINE void set_sl_rr(FM_SLOT *SLOT, int v)
+static INLINE void set_sl_rr(FM_SLOT *SLOT, int v)
 {
 	int eg_sh_rr, eg_sel_rr;
 
@@ -667,8 +667,6 @@ INLINE void set_sl_rr(FM_SLOT *SLOT, int v)
 
 	SLOT->eg_pack_rr = eg_inc_pack[eg_sel_rr] | (eg_sh_rr<<24);
 }
-
-
 
 INLINE signed int op_calc(UINT32 phase, unsigned int env, signed int pm)
 {


### PR DESCRIPTION
This does two things, first it makes it so that it will check if DEBUG is set rather than if its not set. Debug builds should be intentional behavior.

Second this will change debug builds from `-O2` to `-O0` which is correct behavior for debug builds which should not be built with optimizations. The downside is that this will not correctly work with picodrive, but its probably better to expose an issue and then later solve it than to mask it until it causes problems later which are harder to diagnose.

See:

https://github.com/libretro/picodrive/pull/40
https://github.com/libretro/picodrive/issues/29