### PR TITLE
Report git version with library_version

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -25,6 +25,10 @@ CFLAGS ?=
 
 TARGET_NAME := picodrive
 LIBM := -lm
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 asm_memory = 0
 asm_render = 0

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -2,6 +2,11 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 #fix stupid change in ndk r11 that breaks compiling even when the exe would run fine
 LOCAL_DISABLE_FATAL_LINKER_WARNINGS := true
 

--- a/platform/libretro/libretro.c
+++ b/platform/libretro/libretro.c
@@ -539,7 +539,10 @@ void retro_get_system_info(struct retro_system_info *info)
 {
    memset(info, 0, sizeof(*info));
    info->library_name = "PicoDrive";
-   info->library_version = VERSION;
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+   info->library_version = VERSION GIT_VERSION;
    info->valid_extensions = "bin|gen|smd|md|32x|cue|iso|sms";
    info->need_fullpath = true;
 }


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.