### PR TITLE
Add cheat support for Genesis/MegaDrive, CD, and 32X games

### DIFF
--- a/pico/patch.c
+++ b/pico/patch.c
@@ -211,7 +211,8 @@ bad_code:
 
 unsigned int PicoRead16(unsigned int a);
 void PicoWrite16(unsigned int a, unsigned short d);
-
+extern unsigned short m68k_read16(unsigned int a);
+extern void m68k_write16(int a, unsigned short d);
 
 void PicoPatchUnload(void)
 {

--- a/platform/libretro/libretro.c
+++ b/platform/libretro/libretro.c
@@ -725,7 +725,7 @@ void retro_cheat_reset(void)
 void retro_cheat_set(unsigned index, bool enabled, const char *code)
 {
 	patch pt;
-	int array_len = 0;
+	int array_len = PicoPatchCount;
 	char codeCopy[256];
 	char *buff;
 	bool multiline=0;
@@ -741,6 +741,7 @@ void retro_cheat_set(unsigned index, bool enabled, const char *code)
 
 	while (buff != NULL)
 	{
+      log_cb(RETRO_LOG_INFO,"Buff: %s\n",buff);
 		decode(buff, &pt);
 		if (pt.addr == (uint32_t) -1 || pt.data == (uint16_t) -1)
 		{
@@ -774,6 +775,7 @@ void retro_cheat_set(unsigned index, bool enabled, const char *code)
 
 		if (!multiline)
 			break;
+		buff = strtok(NULL,"+");
 	}
 }
 

--- a/platform/libretro/libretro.c
+++ b/platform/libretro/libretro.c
@@ -722,11 +722,17 @@ void retro_cheat_set(unsigned index, bool enabled, const char *code)
 	} pt;
 	int array_len = 0;
 	char *buff;
+	bool multiline=0;
 
 	//TODO: Split multi-line codes properly
-	buff = strtok(code,"+");
+	if (strstr(code,"+")){
+		multiline=1;
+		buff = strtok(code,"+");
+	} else {
+		buff=code;
+	}
 
-	while (buff)
+	while (buff != NULL)
 	{
 		decode(buff, &pt);
 		if (pt.addr == (unsigned int)-1 || pt.data == (unsigned short)-1)
@@ -759,6 +765,9 @@ void retro_cheat_set(unsigned index, bool enabled, const char *code)
 		else
 			PicoPatches[PicoPatchCount].data_old = (unsigned short) m68k_read16(PicoPatches[PicoPatchCount].addr);
 		PicoPatchCount++;
+
+		if (!multiline)
+			break;
 	}
 }
 

--- a/platform/libretro/libretro.c
+++ b/platform/libretro/libretro.c
@@ -713,7 +713,7 @@ void retro_cheat_reset(void)
 	PicoPatchUnload();
 }
 
-void retro_cheat_set(unsigned index, bool enabled, const char *buff)
+void retro_cheat_set(unsigned index, bool enabled, const char *code)
 {
 	struct patch
 	{
@@ -721,11 +721,16 @@ void retro_cheat_set(unsigned index, bool enabled, const char *buff)
 		unsigned short data;
 	} pt;
 	int array_len = 0;
+	char *buff;
 
 	//TODO: Split multi-line codes properly
+	buff = strtok(code,"+");
 
+	while (buff)
+	{
 		decode(buff, &pt);
-		if (pt.addr == (unsigned int)-1 || pt.data == (unsigned short)-1){
+		if (pt.addr == (unsigned int)-1 || pt.data == (unsigned short)-1)
+		{
 			log_cb(RETRO_LOG_ERROR,"CHEATS: Invalid code: %s\n",buff);
 			return;
 		}
@@ -754,6 +759,7 @@ void retro_cheat_set(unsigned index, bool enabled, const char *buff)
 		else
 			PicoPatches[PicoPatchCount].data_old = (unsigned short) m68k_read16(PicoPatches[PicoPatchCount].addr);
 		PicoPatchCount++;
+	}
 }
 
 /* multidisk support */

--- a/platform/libretro/libretro.c
+++ b/platform/libretro/libretro.c
@@ -741,7 +741,6 @@ void retro_cheat_set(unsigned index, bool enabled, const char *code)
 
 	while (buff != NULL)
 	{
-      log_cb(RETRO_LOG_INFO,"Buff: %s\n",buff);
 		decode(buff, &pt);
 		if (pt.addr == (uint32_t) -1 || pt.data == (uint16_t) -1)
 		{


### PR DESCRIPTION
Fixes #25 and then some

Adds support for Game Genie, Genecyst patch, and Action Replay cheats within PicoDrive.
Should also function for Sega CD and 32X games.
Master System cheats not supported, as the Master System has a separate code format not supported by upstream Picodrive.

Game Genie cheats can be formatted as: AAAA-AAAA or AAAAAAAA
Genecyst Patch and Action Replay cheats can be formatted as: 000000:FF or 000000:FFFF
Multiline cheats supported, so long as + is used as a delimiter.