### PR TITLE
libretro: fix unexpected reloc type 0x03 error on Raspberry Pi 3

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -366,7 +366,7 @@ else ifeq ($(platform), qnx)
 # ARM
 else ifneq (,$(findstring armv,$(platform)))
 	TARGET := $(TARGET_NAME)_libretro.so
-	SHARED := -shared -Wl,--no-undefined
+	SHARED := -shared -Wl,--no-undefined,-Bsymbolic
    fpic := -fPIC
 	ifneq (,$(findstring cortexa5,$(platform)))
 		CFLAGS += -marm -mcpu=cortex-a5


### PR DESCRIPTION
Issue is caused by commit 66dda842eae01f47f5389b931ec9567fb0bbb6a1 in
cpu/cyclone submodule.