### PR TITLE
Picodrive core for Solaris

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,9 +179,10 @@ OBJS += $(OBJS_COMMON)
 CFLAGS += $(addprefix -D,$(DEFINES))
 
 ifneq ($(findstring gcc,$(CC)),)
+ifneq ($(findstring SunOS,$(shell uname -a)),SunOS)
 LDFLAGS += -Wl,-Map=$(TARGET).map
 endif
-
+endif
 
 target_: $(TARGET)
 

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -53,6 +53,9 @@ ifeq ($(platform), unix)
 	DONT_COMPILE_IN_ZLIB = 1
 	CFLAGS += -DFAMEC_NO_GOTOS
 	use_sh2drc = 1
+ifneq ($(findstring SunOS,$(shell uname -a)),)
+	CC=gcc
+endif
 
 # Portable Linux
 else ifeq ($(platform), linux-portable)


### PR DESCRIPTION
This allows the Picodrive core to build on Solaris 11 by simply running `gmake -f Makefile.libretro`