### PR TITLE
Add optional low pass audio filter

### DIFF
--- a/pico/pico.h
+++ b/pico/pico.h
@@ -99,6 +99,8 @@ typedef struct
 	unsigned short overclockM68k;  // overclock the emulated 68k, in %
 
 	int sndRate;                   // rate in Hz
+	unsigned short sndFilter;      // Set low pass sound filter 0: off, 1: on (use integer in case we want to add other filter types later)
+	int32_t sndFilterRange;        // Low pass sound filter range [0, 65536]
 	short *sndOut;                 // PCM output buffer
 	void (*writeSound)(int len);   // write .sndOut callback, called once per frame
 

--- a/platform/libretro/libretro.c
+++ b/platform/libretro/libretro.c
@@ -541,6 +541,8 @@ void retro_set_environment(retro_environment_t cb)
 #ifdef DRC_SH2
       { "picodrive_drc", "Dynamic recompilers; enabled|disabled" },
 #endif
+      { "picodrive_audio_filter", "Audio filter; disabled|low-pass" },
+      { "picodrive_lowpass_range", "Low-pass filter %; 60|65|70|75|80|85|90|95|5|10|15|20|25|30|35|40|45|50|55"},
       { NULL, NULL },
    };
 
@@ -1337,6 +1339,21 @@ static void update_variables(void)
    if(!ctr_svchack_successful)
       PicoIn.opt &= ~POPT_EN_DRC;
 #endif
+
+   var.value = NULL;
+   var.key = "picodrive_audio_filter";
+   PicoIn.sndFilter = 0;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
+      if (strcmp(var.value, "low-pass") == 0)
+         PicoIn.sndFilter = 1;
+   }
+
+   var.value = NULL;
+   var.key = "picodrive_lowpass_range";
+   PicoIn.sndFilterRange = (60 * 65536) / 100;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
+      PicoIn.sndFilterRange = (atoi(var.value) * 65536) / 100;
+   }
 }
 
 void retro_run(void)


### PR DESCRIPTION
This core is a marvel on ARM devices, and it's the only way to play Genesis games at full speed with a CPU filter on 3DS (well, n3DS). The only issue I have with it is that the audio is very harsh and 'raw' sounding, due to the lack of a low pass filter.

This pull request solves the issue by importing the low pass filter logic from Genesis Plus GX (with the same core options: enable/disable and filter 'strength'). This makes everything sound much nicer, and it has no discernable performance impact on my n3DS.