### PR TITLE
Add renderer option

### DIFF
--- a/platform/libretro/libretro.c
+++ b/platform/libretro/libretro.c
@@ -1431,6 +1431,15 @@ static void update_variables(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
       PicoIn.sndFilterRange = (atoi(var.value) * 65536) / 100;
    }
+
+   var.value = NULL;
+   var.key = "picodrive_renderer";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
+      if (strcmp(var.value, "fast") == 0)
+         PicoIn.opt |= POPT_ALT_RENDERER;
+      else
+         PicoIn.opt &= ~POPT_ALT_RENDERER;
+   }
 }
 
 void retro_run(void)

--- a/platform/libretro/libretro_core_options.h
+++ b/platform/libretro/libretro_core_options.h
@@ -200,6 +200,7 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "60"
    },
+#if !defined(RENDER_GSKIT_PS2)
    {
       "picodrive_renderer",
       "Renderer",
@@ -211,6 +212,7 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "accurate"
    },
+#endif
    { NULL, NULL, NULL, {{0}}, NULL },
 };
 

--- a/platform/libretro/libretro_core_options.h
+++ b/platform/libretro/libretro_core_options.h
@@ -200,6 +200,17 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "60"
    },
+   {
+      "picodrive_renderer",
+      "Renderer",
+      "Fast renderer can't render any mid-frame image changes so it is useful only for some games.",
+      {
+         { "accurate", NULL },
+         { "fast",  NULL },
+         { NULL, NULL },
+      },
+      "accurate"
+   },
    { NULL, NULL, NULL, {{0}}, NULL },
 };
 


### PR DESCRIPTION
I've added an option to change the renderer from the default "accurate" line-based renderer to an alternative "fast" tile-based renderer, which may improve performance on slower devices such as the PSP. (This was already an option on the native PSP build of picodrive: https://github.com/libretro/picodrive/blob/master/platform/psp/emu.c#L751)

Fixes #112