### PR TITLE
Add option to change sound quality

### DIFF
--- a/platform/libretro/libretro_core_options.h
+++ b/platform/libretro/libretro_core_options.h
@@ -213,6 +213,19 @@ struct retro_core_option_definition option_defs_us[] = {
       "accurate"
    },
 #endif
+   {
+      "picodrive_sound_rate",
+      "Sound quality",
+      "Sound quality (in Hz). A lower value may increase performance.",
+      {
+         { "16000", NULL },
+         { "22050", NULL },
+         { "32000", NULL },
+         { "44100", NULL },
+         { NULL, NULL },
+      },
+      "44100"
+   },
    { NULL, NULL, NULL, {{0}}, NULL },
 };
 


### PR DESCRIPTION
Even with the fast renderer (#116), the framerate on the PSP slows down at some points in some games. Reducing the sound rate can help increase the framerate in these cases.

It's not ideal but it's better than frame skipping.