### PR TITLE
Fix MegaCD RAM cart saving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 tags
 cscope.out
 PicoDrive.map
+*.map
 config.mak
 config.log
 cpu/musashi/m68kmake

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -428,13 +428,13 @@ else ifeq ($(platform), emscripten)
 # GCW0
 else ifeq ($(platform), gcw0)
 	TARGET := $(TARGET_NAME)_libretro.so
-	CC = mipsel-linux-gcc
-	AR = mipsel-linux-ar
+	CC = /opt/gcw0-toolchain/usr/bin/mipsel-linux-gcc
+	AR = /opt/gcw0-toolchain/usr/bin/mipsel-linux-ar
 	SHARED := -shared -nostdlib
 	fpic := -fPIC
 	LIBM :=
 	DONT_COMPILE_IN_ZLIB = 1
-	CFLAGS += -ffast-math -march=mips32 -mtune=mips32r2 -mhard-float
+	CFLAGS += -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32r2 -mhard-float
 
 # Windows MSVC 2017 all architectures
 else ifneq (,$(findstring windows_msvc2017,$(platform)))

--- a/pico/cd/cue.c
+++ b/pico/cd/cue.c
@@ -78,9 +78,11 @@ static int get_ext(const char *fname, char ext[4],
 	strcpy(ext, fname + pos);
 
 	if (base != NULL) {
-		len = pos;
-		if (len + 1 < base_size)
-			len = base_size - 1;
+		if (pos + 1 < base_size)
+			pos = base_size - 1;
+
+		len = (pos < len) ? pos : len;
+
 		memcpy(base, fname, len);
 		base[len] = 0;
 	}

--- a/platform/libretro/libretro.c
+++ b/platform/libretro/libretro.c
@@ -1203,7 +1203,9 @@ void *retro_get_memory_data(unsigned type)
    switch(type)
    {
       case RETRO_MEMORY_SAVE_RAM:
-         if (PicoIn.AHW & PAHW_MCD)
+         /* Note: MCD RAM cart uses Pico.sv.data */
+         if ((PicoIn.AHW & PAHW_MCD) &&
+               !(PicoIn.opt & POPT_EN_MCD_RAMCART))
             data = Pico_mcd->bram;
          else
             data = Pico.sv.data;
@@ -1231,8 +1233,12 @@ size_t retro_get_memory_size(unsigned type)
    {
       case RETRO_MEMORY_SAVE_RAM:
          if (PicoIn.AHW & PAHW_MCD)
-            // bram
-            return 0x2000;
+         {
+            if (PicoIn.opt & POPT_EN_MCD_RAMCART)
+               return 0x12000;
+            else /* bram */
+               return 0x2000;
+         }
 
          if (Pico.m.frame_count == 0)
             return Pico.sv.size;

--- a/platform/libretro/libretro_core_options.h
+++ b/platform/libretro/libretro_core_options.h
@@ -87,7 +87,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "picodrive_ramcart",
       "MegaCD RAM cart",
-      "Emulate a MegaCD RAM cart, used for save game data.",
+      "Emulate a MegaCD RAM cart, used for save game data. WARNING: When enabled, internal save data (BRAM) will be discarded.",
       {
          { "disabled", NULL },
          { "enabled",  NULL },


### PR DESCRIPTION
At present, the `MegaCD RAM cart` option doesn't function correctly: a RAM cart is emulated, but its contents is never saved to disk. This happens because the wrong buffer is exposed in `retro_get_memory_data()`.

This PR fixes the issue.

**Important note:** BRAM and RAM cart are mutually exclusive - if the RAM cart is enabled, BRAM saves will be discarded. This is because the libretro API only allows one data buffer to be accessed via `retro_get_memory_data()`. The core options sublabel has been updated to reflect this fact. Since there are very few (3?) games that require the use of a RAM cart anyway, I don't think this is a problem.

In addition, this PR:

- Fixes a heap buffer overflow in the cue parsing code (noticed while running with ASAN enabled)

- Trivially fixes the OpenDingux makefile target

This PR closes #55