### PR TITLE
[3DS] Fix dynarec crashes and enable for 3dsx builds

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -227,7 +227,7 @@ else ifeq ($(platform), ctr)
 	NO_MMAP = 1
 	DONT_COMPILE_IN_ZLIB = 1
 
-	OBJS +=platform/libretro/3ds/3ds_utils.o
+	OBJS += platform/libretro/3ds/3ds_utils.o platform/libretro/3ds/utils.o
 
 # Raspberry Pi (original model) Raspbian
 else ifeq ($(platform), raspberrypi)

--- a/platform/libretro/3ds/3ds_utils.h
+++ b/platform/libretro/3ds/3ds_utils.h
@@ -4,6 +4,7 @@
 void ctr_flush_invalidate_cache(void);
 
 int ctr_svchack_init(void);
+void check_rosalina(void);
 
 #include <stdio.h>
 #define DEBUG_HOLD() do{printf("%s@%s:%d.\n",__FUNCTION__, __FILE__, __LINE__);fflush(stdout);wait_for_input();}while(0)

--- a/platform/libretro/3ds/utils.S
+++ b/platform/libretro/3ds/utils.S
@@ -1,0 +1,25 @@
+  .text
+  .arm
+  .balign 4
+
+  .func ctr_clear_cache_kernel
+ctr_clear_cache_kernel:
+  cpsid aif
+  mov r0, #0
+  mcr p15, 0, r0, c7, c10, 0    @ Clean entire data cache
+  mcr p15, 0, r0, c7, c10, 5    @ Data Memory Barrier
+  mcr p15, 0, r0, c7, c5, 0     @ Invalidate entire instruction cache / Flush BTB
+  mcr p15, 0, r0, c7, c10, 4    @ Data Sync Barrier
+  bx lr
+  .endfunc
+
+  @@ Clear the entire data cache / invalidate the instruction cache. Uses
+  @@ Rosalina svcCustomBackdoor to avoid svcBackdoor stack corruption
+  @@ during interrupts.
+  .global ctr_clear_cache
+  .func ctr_clear_cache
+ctr_clear_cache:
+  ldr r0, =ctr_clear_cache_kernel
+  svc 0x80                      @ svcCustomBackdoor
+  bx lr
+  .endfunc

--- a/platform/libretro/libretro.c
+++ b/platform/libretro/libretro.c
@@ -1608,6 +1608,7 @@ void retro_init(void)
 
 #ifdef _3DS
    ctr_svchack_successful = ctr_svchack_init();
+   check_rosalina();
 #elif defined(VITA)
    sceBlock = getVMBlock();
 #endif


### PR DESCRIPTION
This enables the dynarec for 3dsx builds of RetroArch and fixes the random crashes using the same strategy as pcsx_rearmed (https://github.com/libretro/pcsx_rearmed/pull/390).

Note that the dynarec does not currently work on 3DS (see https://github.com/libretro/picodrive/issues/135), but this change works with the last working commit I could find (8d2a03b622419677a6998f6554df6b953526cec1).