### PR TITLE
Fix PSP compilation

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -198,8 +198,8 @@ else ifeq ($(platform), psp1)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a
 	CC = psp-gcc$(EXE_EXT)
 	AR = psp-ar$(EXE_EXT)
-	CFLAGS += -G0 -ftracer
-	CFLAGS += -DPSP
+	CFLAGS += -DPSP -DUSE_BGR565 -G0 -ftracer
+	CFLAGS += -I$(shell psp-config --pspsdk-path)/include
 	STATIC_LINKING = 1
 	NO_MMAP = 1
 

--- a/platform/libretro/libretro.c
+++ b/platform/libretro/libretro.c
@@ -234,6 +234,14 @@ int __builtin_parity(unsigned v)
    v ^= v >> 4;
    return (0x6996 >> (v&0xf)) & 1;
 }
+#elif defined(PSP)
+int _flush_cache(char *addr, const int size, const int op)
+{
+   //sceKernelDcacheWritebackAll();
+   sceKernelDcacheWritebackRange(addr, size);
+   sceKernelIcacheInvalidateRange(addr, size);
+   return 0;
+}
 #endif
 
 #ifdef __MACH__


### PR DESCRIPTION
Prior to f8a685534411fdbd9d8b2bff994cff729d559f7e, we were mistakenly building the core for Vita in the PSP job of the gitlab pipeline. Now that we are attempting to build the correct PSP core, it seems that compilation fails due to an `undefined reference to '_flush_cache'` error.

This 'band-aid' PR fixes PSP compilation. I am unable to test whether the core actually runs on PSP, but this at least enables the gitlab pipeline to run successfully.