### PR TITLE
Add support for RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE API extension - enables soft patching of non-CD content

### DIFF
--- a/pico/cart.c
+++ b/pico/cart.c
@@ -740,65 +740,75 @@ static unsigned char *PicoCartAlloc(int filesize, int is_sms)
   return rom;
 }
 
-int PicoCartLoad(pm_file *f,unsigned char **prom,unsigned int *psize,int is_sms)
+int PicoCartLoad(pm_file *f, const unsigned char *rom, unsigned int romsize,
+  unsigned char **prom, unsigned int *psize, int is_sms)
 {
-  unsigned char *rom;
+  unsigned char *rom_data = NULL;
   int size, bytes_read;
 
-  if (f == NULL)
+  if (!f && !rom)
     return 1;
 
-  size = f->size;
+  if (!rom)
+    size = f->size;
+  else
+    size = romsize;
+
   if (size <= 0) return 1;
   size = (size+3)&~3; // Round up to a multiple of 4
 
   // Allocate space for the rom plus padding
-  rom = PicoCartAlloc(size, is_sms);
-  if (rom == NULL) {
+  rom_data = PicoCartAlloc(size, is_sms);
+  if (rom_data == NULL) {
     elprintf(EL_STATUS, "out of memory (wanted %i)", size);
     return 2;
   }
 
-  if (PicoCartLoadProgressCB != NULL)
-  {
-    // read ROM in blocks, just for fun
-    int ret;
-    unsigned char *p = rom;
-    bytes_read=0;
-    do
+  if (!rom) {
+    if (PicoCartLoadProgressCB != NULL)
     {
-      int todo = size - bytes_read;
-      if (todo > 256*1024) todo = 256*1024;
-      ret = pm_read(p,todo,f);
-      bytes_read += ret;
-      p += ret;
-      PicoCartLoadProgressCB(bytes_read * 100 / size);
+      // read ROM in blocks, just for fun
+      int ret;
+      unsigned char *p = rom_data;
+      bytes_read=0;
+      do
+      {
+        int todo = size - bytes_read;
+        if (todo > 256*1024) todo = 256*1024;
+        ret = pm_read(p,todo,f);
+        bytes_read += ret;
+        p += ret;
+        PicoCartLoadProgressCB(bytes_read * 100 / size);
+      }
+      while (ret > 0);
     }
-    while (ret > 0);
+    else
+      bytes_read = pm_read(rom_data,size,f); // Load up the rom
+
+    if (bytes_read <= 0) {
+      elprintf(EL_STATUS, "read failed");
+      plat_munmap(rom_data, rom_alloc_size);
+      return 3;
+    }
   }
   else
-    bytes_read = pm_read(rom,size,f); // Load up the rom
-  if (bytes_read <= 0) {
-    elprintf(EL_STATUS, "read failed");
-    plat_munmap(rom, rom_alloc_size);
-    return 3;
-  }
+    memcpy(rom_data, rom, romsize);
 
   if (!is_sms)
   {
     // maybe we are loading MegaCD BIOS?
-    if (!(PicoIn.AHW & PAHW_MCD) && size == 0x20000 && (!strncmp((char *)rom+0x124, "BOOT", 4) ||
-         !strncmp((char *)rom+0x128, "BOOT", 4))) {
+    if (!(PicoIn.AHW & PAHW_MCD) && size == 0x20000 && (!strncmp((char *)rom_data+0x124, "BOOT", 4) ||
+         !strncmp((char *)rom_data+0x128, "BOOT", 4))) {
       PicoIn.AHW |= PAHW_MCD;
     }
 
     // Check for SMD:
     if (size >= 0x4200 && (size&0x3fff) == 0x200 &&
-        ((rom[0x2280] == 'S' && rom[0x280] == 'E') || (rom[0x280] == 'S' && rom[0x2281] == 'E'))) {
+        ((rom_data[0x2280] == 'S' && rom_data[0x280] == 'E') || (rom_data[0x280] == 'S' && rom_data[0x2281] == 'E'))) {
       elprintf(EL_STATUS, "SMD format detected.");
-      DecodeSmd(rom,size); size-=0x200; // Decode and byteswap SMD
+      DecodeSmd(rom_data,size); size-=0x200; // Decode and byteswap SMD
     }
-    else Byteswap(rom, rom, size); // Just byteswap
+    else Byteswap(rom_data, rom_data, size); // Just byteswap
   }
   else
   {
@@ -806,11 +816,11 @@ int PicoCartLoad(pm_file *f,unsigned char **prom,unsigned int *psize,int is_sms)
       elprintf(EL_STATUS, "SMD format detected.");
       // at least here it's not interleaved
       size -= 0x200;
-      memmove(rom, rom + 0x200, size);
+      memmove(rom_data, rom_data + 0x200, size);
     }
   }
 
-  if (prom)  *prom = rom;
+  if (prom)  *prom = rom_data;
   if (psize) *psize = size;
 
   return 0;

--- a/pico/media.c
+++ b/pico/media.c
@@ -31,34 +31,49 @@ static void get_ext(const char *file, char *ext)
   strlwr_(ext);
 }
 
-static int detect_media(const char *fname)
+static int detect_media(const char *fname, const unsigned char *rom, unsigned int romsize)
 {
   static const short sms_offsets[] = { 0x7ff0, 0x3ff0, 0x1ff0 };
   static const char *sms_exts[] = { "sms", "gg", "sg" };
   static const char *md_exts[] = { "gen", "bin", "smd" };
   char buff0[32], buff[32];
-  unsigned short *d16;
-  pm_file *pmf;
-  char ext[5];
+  unsigned short *d16 = NULL;
+  pm_file *pmf = NULL;
+  const char *ext_ptr = NULL;
+  char ext[8];
   int i;
 
-  get_ext(fname, ext);
+  ext[0] = '\0';
+  if ((ext_ptr = strrchr(fname, '.'))) {
+    strncpy(ext, ext_ptr + 1, sizeof(ext));
+    ext[sizeof(ext) - 1] = '\0';
+  }
 
   // detect wrong extensions
-  if (!strcmp(ext, ".srm") || !strcmp(ext, "s.gz") || !strcmp(ext, ".mds")) // s.gz ~ .mds.gz
+  if (!strcmp(ext, "srm") || !strcmp(ext, "gz")) // s.gz ~ .mds.gz
     return PM_BAD_DETECT;
 
-  /* don't believe in extensions, except .cue */
-  if (strcasecmp(ext, ".cue") == 0 || strcasecmp(ext, ".chd") == 0)
+  /* don't believe in extensions, except .cue and .chd */
+  if (strcasecmp(ext, "cue") == 0 || strcasecmp(ext, "chd") == 0)
     return PM_CD;
 
-  pmf = pm_open(fname);
-  if (pmf == NULL)
-    return PM_BAD_DETECT;
+  /* Open rom file, if required */
+  if (!rom) {
+    pmf = pm_open(fname);
+    if (pmf == NULL)
+      return PM_BAD_DETECT;
+    romsize = pmf->size;
+  }
 
-  if (pm_read(buff0, 32, pmf) != 32) {
-    pm_close(pmf);
-    return PM_BAD_DETECT;
+  if (!rom) {
+    if (pm_read(buff0, 32, pmf) != 32) {
+      pm_close(pmf);
+      return PM_BAD_DETECT;
+    }
+  } else {
+    if (romsize < 32)
+      return PM_BAD_DETECT;
+    memcpy(buff0, rom, 32);
   }
 
   if (strncasecmp("SEGADISCSYSTEM", buff0 + 0x00, 14) == 0 ||
@@ -68,10 +83,18 @@ static int detect_media(const char *fname)
   }
 
   /* check for SMD evil */
-  if (pmf->size >= 0x4200 && (pmf->size & 0x3fff) == 0x200) {
-    if (pm_seek(pmf, sms_offsets[0] + 0x200, SEEK_SET) == sms_offsets[0] + 0x200 &&
-        pm_read(buff, 16, pmf) == 16 &&
-        strncmp("TMR SEGA", buff, 8) == 0)
+  if (romsize >= 0x4200 && (romsize & 0x3fff) == 0x200) {
+    buff[0] = '\0';
+
+    if (!rom) {
+      if (pm_seek(pmf, sms_offsets[0] + 0x200, SEEK_SET) == sms_offsets[0] + 0x200)
+        pm_read(buff, 16, pmf);
+    } else {
+      if (romsize >= sms_offsets[0] + 0x200 + 16)
+        memcpy(buff, rom + sms_offsets[0] + 0x200, 16);
+    }
+
+    if (strncmp("TMR SEGA", buff, 8) == 0)
       goto looks_like_sms;
 
     /* could parse further but don't bother */
@@ -79,17 +102,31 @@ static int detect_media(const char *fname)
   }
 
   /* MD header? Act as TMSS BIOS here */
-  if (pm_seek(pmf, 0x100, SEEK_SET) == 0x100 && pm_read(buff, 16, pmf) == 16) {
-    if (strncmp(buff, "SEGA", 4) == 0 || strncmp(buff, " SEG", 4) == 0)
-      goto looks_like_md;
+  buff[0] = '\0';
+  if (!rom) {
+    if (pm_seek(pmf, 0x100, SEEK_SET) == 0x100)
+      pm_read(buff, 16, pmf);
+  } else {
+    if (romsize >= 0x100 + 16)
+      memcpy(buff, rom + 0x100, 16);
   }
 
-  for (i = 0; i < ARRAY_SIZE(sms_offsets); i++) {
-    if (pm_seek(pmf, sms_offsets[i], SEEK_SET) != sms_offsets[i])
-      continue;
+  if (strncmp(buff, "SEGA", 4) == 0 || strncmp(buff, " SEG", 4) == 0)
+    goto looks_like_md;
 
-    if (pm_read(buff, 16, pmf) != 16)
-      continue;
+  for (i = 0; i < ARRAY_SIZE(sms_offsets); i++) {
+    if (!rom) {
+      if (pm_seek(pmf, sms_offsets[i], SEEK_SET) != sms_offsets[i])
+        continue;
+
+      if (pm_read(buff, 16, pmf) != 16)
+        continue;
+    } else {
+      if (romsize < sms_offsets[i] + 16)
+        continue;
+
+      memcpy(buff, rom + sms_offsets[i], 16);
+    }
 
     if (strncmp("TMR SEGA", buff, 8) == 0)
       goto looks_like_sms;
@@ -98,16 +135,16 @@ static int detect_media(const char *fname)
 extension_check:
   /* probably some headerless thing. Maybe check the extension after all. */
   for (i = 0; i < ARRAY_SIZE(md_exts); i++)
-    if (strcasecmp(pmf->ext, md_exts[i]) == 0)
+    if (strcasecmp(ext, md_exts[i]) == 0)
       goto looks_like_md;
 
   for (i = 0; i < ARRAY_SIZE(sms_exts); i++)
-    if (strcasecmp(pmf->ext, sms_exts[i]) == 0)
+    if (strcasecmp(ext, sms_exts[i]) == 0)
       goto looks_like_sms;
 
   /* If everything else fails, make a guess on the reset vector */
   d16 = (unsigned short *)(buff0 + 4);
-  if ((((d16[0] << 16) | d16[1]) & 0xffffff) >= pmf->size) {
+  if ((((d16[0] << 16) | d16[1]) & 0xffffff) >= romsize) {
     lprintf("bad MD reset vector, assuming SMS\n");
     goto looks_like_sms;
   }
@@ -197,6 +234,7 @@ int PicoCdCheck(const char *fname_in, int *pregion)
 }
 
 enum media_type_e PicoLoadMedia(const char *filename,
+  const unsigned char *rom, unsigned int romsize,
   const char *carthw_cfg_fname,
   const char *(*get_bios_filename)(int *region, const char *cd_fname),
   void (*do_region_override)(const char *media_filename))
@@ -204,13 +242,13 @@ enum media_type_e PicoLoadMedia(const char *filename,
   const char *rom_fname = filename;
   enum media_type_e media_type;
   enum cd_track_type cd_img_type = CT_UNKNOWN;
+  pm_file *rom_file = NULL;
   unsigned char *rom_data = NULL;
   unsigned int rom_size = 0;
-  pm_file *rom = NULL;
   int cd_region = 0;
   int ret;
 
-  media_type = detect_media(filename);
+  media_type = detect_media(filename, rom, romsize);
   if (media_type == PM_BAD_DETECT)
     goto out;
 
@@ -247,15 +285,17 @@ enum media_type_e PicoLoadMedia(const char *filename,
     PicoIn.AHW = PAHW_SMS;
   }
 
-  rom = pm_open(rom_fname);
-  if (rom == NULL) {
-    lprintf("Failed to open ROM\n");
-    media_type = PM_ERROR;
-    goto out;
+  if (!rom) {
+    rom_file = pm_open(rom_fname);
+    if (rom_file == NULL) {
+      lprintf("Failed to open ROM\n");
+      media_type = PM_ERROR;
+      goto out;
+    }
   }
 
-  ret = PicoCartLoad(rom, &rom_data, &rom_size, (PicoIn.AHW & PAHW_SMS) ? 1 : 0);
-  pm_close(rom);
+  ret = PicoCartLoad(rom_file, rom, romsize, &rom_data, &rom_size, (PicoIn.AHW & PAHW_SMS) ? 1 : 0);
+  pm_close(rom_file);
   if (ret != 0) {
     if      (ret == 2) lprintf("Out of memory\n");
     else if (ret == 3) lprintf("Read failed\n");

--- a/pico/pico.h
+++ b/pico/pico.h
@@ -177,7 +177,8 @@ size_t   pm_read(void *ptr, size_t bytes, pm_file *stream);
 size_t   pm_read_audio(void *ptr, size_t bytes, pm_file *stream);
 int      pm_seek(pm_file *stream, long offset, int whence);
 int      pm_close(pm_file *fp);
-int PicoCartLoad(pm_file *f,unsigned char **prom,unsigned int *psize,int is_sms);
+int PicoCartLoad(pm_file *f, const unsigned char *rom, unsigned int romsize,
+  unsigned char **prom, unsigned int *psize, int is_sms);
 int PicoCartInsert(unsigned char *rom, unsigned int romsize, const char *carthw_cfg);
 void PicoCartUnload(void);
 extern void (*PicoCartLoadProgressCB)(int percent);
@@ -286,6 +287,7 @@ typedef struct
 
 
 enum media_type_e PicoLoadMedia(const char *filename,
+  const unsigned char *rom, unsigned int romsize,
   const char *carthw_cfg_fname,
   const char *(*get_bios_filename)(int *region, const char *cd_fname),
   void (*do_region_override)(const char *media_filename));

--- a/platform/common/emu.c
+++ b/platform/common/emu.c
@@ -439,7 +439,7 @@ int emu_reload_rom(const char *rom_fname_in)
 
 	emu_make_path(carthw_path, "carthw.cfg", sizeof(carthw_path));
 
-	media_type = PicoLoadMedia(rom_fname, carthw_path,
+	media_type = PicoLoadMedia(rom_fname, NULL, 0, carthw_path,
 			find_bios, do_region_override);
 
 	switch (media_type) {

--- a/platform/libretro/libretro-common/include/libretro.h
+++ b/platform/libretro/libretro-common/include/libretro.h
@@ -1378,6 +1378,121 @@ enum retro_mod
                                             * call will target the newly initialized driver.
                                             */
 
+#define RETRO_ENVIRONMENT_SET_FASTFORWARDING_OVERRIDE 64
+                                           /* const struct retro_fastforwarding_override * --
+                                            * Used by a libretro core to override the current
+                                            * fastforwarding mode of the frontend.
+                                            * If NULL is passed to this function, the frontend
+                                            * will return true if fastforwarding override
+                                            * functionality is supported (no change in
+                                            * fastforwarding state will occur in this case).
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE 65
+                                           /* const struct retro_system_content_info_override * --
+                                            * Allows an implementation to override 'global' content
+                                            * info parameters reported by retro_get_system_info().
+                                            * Overrides also affect subsystem content info parameters
+                                            * set via RETRO_ENVIRONMENT_SET_SUBSYSTEM_INFO.
+                                            * This function must be called inside retro_set_environment().
+                                            * If callback returns false, content info overrides
+                                            * are unsupported by the frontend, and will be ignored.
+                                            * If callback returns true, extended game info may be
+                                            * retrieved by calling RETRO_ENVIRONMENT_GET_GAME_INFO_EXT
+                                            * in retro_load_game() or retro_load_game_special().
+                                            *
+                                            * 'data' points to an array of retro_system_content_info_override
+                                            * structs terminated by a { NULL, false, false } element.
+                                            * If 'data' is NULL, no changes will be made to the frontend;
+                                            * a core may therefore pass NULL in order to test whether
+                                            * the RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE and
+                                            * RETRO_ENVIRONMENT_GET_GAME_INFO_EXT callbacks are supported
+                                            * by the frontend.
+                                            *
+                                            * For struct member descriptions, see the definition of
+                                            * struct retro_system_content_info_override.
+                                            *
+                                            * Example:
+                                            *
+                                            * - struct retro_system_info:
+                                            * {
+                                            *    "My Core",                      // library_name
+                                            *    "v1.0",                         // library_version
+                                            *    "m3u|md|cue|iso|chd|sms|gg|sg", // valid_extensions
+                                            *    true,                           // need_fullpath
+                                            *    false                           // block_extract
+                                            * }
+                                            *
+                                            * - Array of struct retro_system_content_info_override:
+                                            * {
+                                            *    {
+                                            *       "md|sms|gg", // extensions
+                                            *       false,       // need_fullpath
+                                            *       true         // persistent_data
+                                            *    },
+                                            *    {
+                                            *       "sg",        // extensions
+                                            *       false,       // need_fullpath
+                                            *       false        // persistent_data
+                                            *    },
+                                            *    { NULL, false, false }
+                                            * }
+                                            *
+                                            * Result:
+                                            * - Files of type m3u, cue, iso, chd will not be
+                                            *   loaded by the frontend. Frontend will pass a
+                                            *   valid path to the core, and core will handle
+                                            *   loading internally
+                                            * - Files of type md, sms, gg will be loaded by
+                                            *   the frontend. A valid memory buffer will be
+                                            *   passed to the core. This memory buffer will
+                                            *   remain valid until retro_deinit() returns
+                                            * - Files of type sg will be loaded by the frontend.
+                                            *   A valid memory buffer will be passed to the core.
+                                            *   This memory buffer will remain valid until
+                                            *   retro_load_game() (or retro_load_game_special())
+                                            *   returns
+                                            *
+                                            * NOTE: If an extension is listed multiple times in
+                                            * an array of retro_system_content_info_override
+                                            * structs, only the first instance will be registered
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_GAME_INFO_EXT 66
+                                           /* const struct retro_game_info_ext ** --
+                                            * Allows an implementation to fetch extended game
+                                            * information, providing additional content path
+                                            * and memory buffer status details.
+                                            * This function may only be called inside
+                                            * retro_load_game() or retro_load_game_special().
+                                            * If callback returns false, extended game information
+                                            * is unsupported by the frontend. In this case, only
+                                            * regular retro_game_info will be available.
+                                            * RETRO_ENVIRONMENT_GET_GAME_INFO_EXT is guaranteed
+                                            * to return true if RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE
+                                            * returns true.
+                                            *
+                                            * 'data' points to an array of retro_game_info_ext structs.
+                                            *
+                                            * For struct member descriptions, see the definition of
+                                            * struct retro_game_info_ext.
+                                            *
+                                            * - If function is called inside retro_load_game(),
+                                            *   the retro_game_info_ext array is guaranteed to
+                                            *   have a size of 1 - i.e. the returned pointer may
+                                            *   be used to access directly the members of the
+                                            *   first retro_game_info_ext struct, for example:
+                                            *
+                                            *      struct retro_game_info_ext *game_info_ext;
+                                            *      if (environ_cb(RETRO_ENVIRONMENT_GET_GAME_INFO_EXT, &game_info_ext))
+                                            *         printf("Content Directory: %s\n", game_info_ext->dir);
+                                            *
+                                            * - If the function is called inside retro_load_game_special(),
+                                            *   the retro_game_info_ext array is guaranteed to have a
+                                            *   size equal to the num_info argument passed to
+                                            *   retro_load_game_special()
+                                            */
+
 /* VFS functionality */
 
 /* File paths:
@@ -2781,6 +2896,213 @@ struct retro_system_info
    bool        block_extract;
 };
 
+/* Defines overrides which modify frontend handling of
+ * specific content file types.
+ * An array of retro_system_content_info_override is
+ * passed to RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE
+ * NOTE: In the following descriptions, references to
+ *       retro_load_game() may be replaced with
+ *       retro_load_game_special() */
+struct retro_system_content_info_override
+{
+   /* A list of file extensions for which the override
+    * should apply, delimited by a 'pipe' character
+    * (e.g. "md|sms|gg")
+    * Permitted file extensions are limited to those
+    * included in retro_system_info::valid_extensions
+    * and/or retro_subsystem_rom_info::valid_extensions */
+   const char *extensions;
+
+   /* Overrides the need_fullpath value set in
+    * retro_system_info and/or retro_subsystem_rom_info.
+    * To reiterate:
+    *
+    * If need_fullpath is true and retro_load_game() is called:
+    *    - retro_game_info::path is guaranteed to contain a valid
+    *      path to an existent file
+    *    - retro_game_info::data and retro_game_info::size are invalid
+    *
+    * If need_fullpath is false and retro_load_game() is called:
+    *    - retro_game_info::path may be NULL
+    *    - retro_game_info::data and retro_game_info::size are guaranteed
+    *      to be valid
+    *
+    * In addition:
+    *
+    * If need_fullpath is true and retro_load_game() is called:
+    *    - retro_game_info_ext::full_path is guaranteed to contain a valid
+    *      path to an existent file
+    *    - retro_game_info_ext::archive_path may be NULL
+    *    - retro_game_info_ext::archive_file may be NULL
+    *    - retro_game_info_ext::dir is guaranteed to contain a valid path
+    *      to the directory in which the content file exists
+    *    - retro_game_info_ext::name is guaranteed to contain the
+    *      basename of the content file, without extension
+    *    - retro_game_info_ext::ext is guaranteed to contain the
+    *      extension of the content file in lower case format
+    *    - retro_game_info_ext::data and retro_game_info_ext::size
+    *      are invalid
+    *
+    * If need_fullpath is false and retro_load_game() is called:
+    *    - If retro_game_info_ext::file_in_archive is false:
+    *       - retro_game_info_ext::full_path is guaranteed to contain
+    *         a valid path to an existent file
+    *       - retro_game_info_ext::archive_path may be NULL
+    *       - retro_game_info_ext::archive_file may be NULL
+    *       - retro_game_info_ext::dir is guaranteed to contain a
+    *         valid path to the directory in which the content file exists
+    *       - retro_game_info_ext::name is guaranteed to contain the
+    *         basename of the content file, without extension
+    *       - retro_game_info_ext::ext is guaranteed to contain the
+    *         extension of the content file in lower case format
+    *    - If retro_game_info_ext::file_in_archive is true:
+    *       - retro_game_info_ext::full_path may be NULL
+    *       - retro_game_info_ext::archive_path is guaranteed to
+    *         contain a valid path to an existent compressed file
+    *         inside which the content file is located
+    *       - retro_game_info_ext::archive_file is guaranteed to
+    *         contain a valid path to an existent content file
+    *         inside the compressed file referred to by
+    *         retro_game_info_ext::archive_path
+    *            e.g. for a compressed file '/path/to/foo.zip'
+    *            containing 'bar.sfc'
+    *             > retro_game_info_ext::archive_path will be '/path/to/foo.zip'
+    *             > retro_game_info_ext::archive_file will be 'bar.sfc'
+    *       - retro_game_info_ext::dir is guaranteed to contain a
+    *         valid path to the directory in which the compressed file
+    *         (containing the content file) exists
+    *       - retro_game_info_ext::name is guaranteed to contain
+    *         EITHER
+    *         1) the basename of the compressed file (containing
+    *            the content file), without extension
+    *         OR
+    *         2) the basename of the content file inside the
+    *            compressed file, without extension
+    *         In either case, a core should consider 'name' to
+    *         be the canonical name/ID of the the content file
+    *       - retro_game_info_ext::ext is guaranteed to contain the
+    *         extension of the content file inside the compressed file,
+    *         in lower case format
+    *    - retro_game_info_ext::data and retro_game_info_ext::size are
+    *      guaranteed to be valid */
+   bool need_fullpath;
+
+   /* If need_fullpath is false, specifies whether the content
+    * data buffer available in retro_load_game() is 'persistent'
+    *
+    * If persistent_data is false and retro_load_game() is called:
+    *    - retro_game_info::data and retro_game_info::size
+    *      are valid only until retro_load_game() returns
+    *    - retro_game_info_ext::data and retro_game_info_ext::size
+    *      are valid only until retro_load_game() returns
+    *
+    * If persistent_data is true and retro_load_game() is called:
+    *    - retro_game_info::data and retro_game_info::size
+    *      are valid until retro_deinit() returns
+    *    - retro_game_info_ext::data and retro_game_info_ext::size
+    *      are valid until retro_deinit() returns */
+   bool persistent_data;
+};
+
+/* Similar to retro_game_info, but provides extended
+ * information about the source content file and
+ * game memory buffer status.
+ * And array of retro_game_info_ext is returned by
+ * RETRO_ENVIRONMENT_GET_GAME_INFO_EXT
+ * NOTE: In the following descriptions, references to
+ *       retro_load_game() may be replaced with
+ *       retro_load_game_special() */
+struct retro_game_info_ext
+{
+   /* - If file_in_archive is false, contains a valid
+    *   path to an existent content file (UTF-8 encoded)
+    * - If file_in_archive is true, may be NULL */
+   const char *full_path;
+
+   /* - If file_in_archive is false, may be NULL
+    * - If file_in_archive is true, contains a valid path
+    *   to an existent compressed file inside which the
+    *   content file is located (UTF-8 encoded) */
+   const char *archive_path;
+
+   /* - If file_in_archive is false, may be NULL
+    * - If file_in_archive is true, contain a valid path
+    *   to an existent content file inside the compressed
+    *   file referred to by archive_path (UTF-8 encoded)
+    *      e.g. for a compressed file '/path/to/foo.zip'
+    *      containing 'bar.sfc'
+    *      > archive_path will be '/path/to/foo.zip'
+    *      > archive_file will be 'bar.sfc' */
+   const char *archive_file;
+
+   /* - If file_in_archive is false, contains a valid path
+    *   to the directory in which the content file exists
+    *   (UTF-8 encoded)
+    * - If file_in_archive is true, contains a valid path
+    *   to the directory in which the compressed file
+    *   (containing the content file) exists (UTF-8 encoded) */
+   const char *dir;
+
+   /* Contains the canonical name/ID of the content file
+    * (UTF-8 encoded). Intended for use when identifying
+    * 'complementary' content named after the loaded file -
+    * i.e. companion data of a different format (a CD image
+    * required by a ROM), texture packs, internally handled
+    * save files, etc.
+    * - If file_in_archive is false, contains the basename
+    *   of the content file, without extension
+    * - If file_in_archive is true, then string is
+    *   implementation specific. A frontend may choose to
+    *   set a name value of:
+    *   EITHER
+    *   1) the basename of the compressed file (containing
+    *      the content file), without extension
+    *   OR
+    *   2) the basename of the content file inside the
+    *      compressed file, without extension
+    *   RetroArch sets the 'name' value according to (1).
+    *   A frontend that supports routine loading of
+    *   content from archives containing multiple unrelated
+    *   content files may set the 'name' value according
+    *   to (2). */
+   const char *name;
+
+   /* - If file_in_archive is false, contains the extension
+    *   of the content file in lower case format
+    * - If file_in_archive is true, contains the extension
+    *   of the content file inside the compressed file,
+    *   in lower case format */
+   const char *ext;
+
+   /* String of implementation specific meta-data. */
+   const char *meta;
+
+   /* Memory buffer of loaded game content. Will be NULL:
+    * IF
+    * - retro_system_info::need_fullpath is true and
+    *   retro_system_content_info_override::need_fullpath
+    *   is unset
+    * OR
+    * - retro_system_content_info_override::need_fullpath
+    *   is true */
+   const void *data;
+
+   /* Size of game content memory buffer, in bytes */
+   size_t size;
+
+   /* True if loaded content file is inside a compressed
+    * archive */
+   bool file_in_archive;
+
+   /* - If data is NULL, value is unset/ignored
+    * - If data is non-NULL:
+    *   - If persistent_data is false, data and size are
+    *     valid only until retro_load_game() returns
+    *   - If persistent_data is true, data and size are
+    *     are valid until retro_deinit() returns */
+   bool persistent_data;
+};
+
 struct retro_game_geometry
 {
    unsigned base_width;    /* Nominal video width of game. */
@@ -2936,6 +3258,47 @@ struct retro_framebuffer
    unsigned memory_flags;           /* Flags telling core how the memory has been mapped.
                                        RETRO_MEMORY_TYPE_* flags.
                                        Set by frontend in GET_CURRENT_SOFTWARE_FRAMEBUFFER. */
+};
+
+/* Used by a libretro core to override the current
+ * fastforwarding mode of the frontend */
+struct retro_fastforwarding_override
+{
+   /* Specifies the runtime speed multiplier that
+    * will be applied when 'fastforward' is true.
+    * For example, a value of 5.0 when running 60 FPS
+    * content will cap the fast-forward rate at 300 FPS.
+    * Note that the target multiplier may not be achieved
+    * if the host hardware has insufficient processing
+    * power.
+    * Setting a value of 0.0 (or greater than 0.0 but
+    * less than 1.0) will result in an uncapped
+    * fast-forward rate (limited only by hardware
+    * capacity).
+    * If the value is negative, it will be ignored
+    * (i.e. the frontend will use a runtime speed
+    * multiplier of its own choosing) */
+   float ratio;
+
+   /* If true, fastforwarding mode will be enabled.
+    * If false, fastforwarding mode will be disabled. */
+   bool fastforward;
+
+   /* If true, and if supported by the frontend, an
+    * on-screen notification will be displayed while
+    * 'fastforward' is true.
+    * If false, and if supported by the frontend, any
+    * on-screen fast-forward notifications will be
+    * suppressed */
+   bool notification;
+
+   /* If true, the core will have sole control over
+    * when fastforwarding mode is enabled/disabled;
+    * the frontend will not be able to change the
+    * state set by 'fastforward' until either
+    * 'inhibit_toggle' is set to false, or the core
+    * is unloaded */
+   bool inhibit_toggle;
 };
 
 /* Callbacks */


### PR DESCRIPTION
This PR adds support for the new libretro `RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE` API extension introduced here: libretro/RetroArch#12473

Using this extension, the core's `need_fullpath` requirement is suspended for content of the following file types: `.gen`, `.smd`, `.md`, `.32x`, `.sms`

As a result:

- Frontend softpatching is now supported for these file types
- When loading these file types from compressed archives, it is no longer necessary for the frontend to extract the content to a temporary file on-disk
