### PR TITLE
Fix minor typo (harmless cast of a buffer to an incorrect type)

### DIFF
--- a/platform/libretro/libretro.c
+++ b/platform/libretro/libretro.c
@@ -1505,7 +1505,7 @@ bool retro_load_game(const struct retro_game_info *info)
    /* Attempt to fetch extended game info */
    if (environ_cb(RETRO_ENVIRONMENT_GET_GAME_INFO_EXT, &info_ext))
    {
-      content_data = (const char *)info_ext->data;
+      content_data = (const unsigned char *)info_ext->data;
       content_size = info_ext->size;
 
       strncpy(base_dir, info_ext->dir, sizeof(base_dir));


### PR DESCRIPTION
This trivial PR fixes an improper cast due to a typo. This is harmless, since the affected buffer is implicitly cast to the correct type immediately after, but typos should not be tolerated....