### PR TITLE
Add 'LOW_MEMORY' build flag to force content loading from file on RAM-limited platforms

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -36,6 +36,7 @@ CFLAGS += -I platform/libretro/libretro-common/include/vfs
 
 STATIC_LINKING:= 0
 STATIC_LINKING_LINK:= 0
+LOW_MEMORY := 0
 TARGET_NAME := picodrive
 LIBM := -lm
 GIT_VERSION ?= $(shell git rev-parse --short HEAD || echo unknown)
@@ -461,6 +462,7 @@ endif
 	CFLAGS += -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32 -D__GCW0__
 	# clear_cache uses SYNCI instead of a syscall
 	CFLAGS += -DMIPS_USE_SYNCI
+	LOW_MEMORY = 1
 
 # GCW0
 else ifeq ($(platform), gcw0)
@@ -595,6 +597,10 @@ endif
 
 ifeq ($(NO_MMAP),1)
 	CFLAGS += -DNO_MMAP
+endif
+
+ifeq ($(LOW_MEMORY), 1)
+	CFLAGS += -DLOW_MEMORY
 endif
 
 ifeq ($(NO_ARM_ASM),1)

--- a/platform/libretro/libretro.c
+++ b/platform/libretro/libretro.c
@@ -730,7 +730,11 @@ void retro_set_environment(retro_environment_t cb)
    static const struct retro_system_content_info_override content_overrides[] = {
       {
          "gen|smd|md|32x|sms", /* extensions */
+#if defined(LOW_MEMORY)
+         true,                 /* need_fullpath */
+#else
          false,                /* need_fullpath */
+#endif
          false                 /* persistent_data */
       },
       { NULL, false, false }
@@ -1505,9 +1509,10 @@ bool retro_load_game(const struct retro_game_info *info)
    /* Attempt to fetch extended game info */
    if (environ_cb(RETRO_ENVIRONMENT_GET_GAME_INFO_EXT, &info_ext))
    {
+#if !defined(LOW_MEMORY)
       content_data = (const unsigned char *)info_ext->data;
       content_size = info_ext->size;
-
+#endif
       strncpy(base_dir, info_ext->dir, sizeof(base_dir));
       base_dir[sizeof(base_dir) - 1] = '\0';
 
@@ -1541,9 +1546,6 @@ bool retro_load_game(const struct retro_game_info *info)
             log_cb(RETRO_LOG_ERROR, "info->path required\n");
          return false;
       }
-
-      content_data = NULL;
-      content_size = 0;
 
       extract_directory(base_dir, info->path, sizeof(base_dir));
 


### PR DESCRIPTION
This PR adds a `LOW_MEMORY` build flag which forces the core to set `need_fullpath = true` - meaning that ROM data will be read directly from file rather than being passed as a frontend-provided data buffer. This is required for very low memory platforms, where the use of an 'external' memory buffer (which must be duplicated in the core) can exceed the total system RAM.

At present, this flag is only enabled for the RS-90 build. This allows 4MB ROMs to be loaded successfully (without the flag, the core will simply crash when attempting to launch such content)