### PR TITLE
Add 'Sega Classics' file types (.68k, .sgd) to valid extensions

### DIFF
--- a/platform/libretro/libretro.c
+++ b/platform/libretro/libretro.c
@@ -729,13 +729,13 @@ void retro_set_environment(retro_environment_t cb)
 
    static const struct retro_system_content_info_override content_overrides[] = {
       {
-         "gen|smd|md|32x|sms", /* extensions */
+         "gen|smd|md|32x|sms|68k|sgd", /* extensions */
 #if defined(LOW_MEMORY)
-         true,                 /* need_fullpath */
+         true,                         /* need_fullpath */
 #else
-         false,                /* need_fullpath */
+         false,                        /* need_fullpath */
 #endif
-         false                 /* persistent_data */
+         false                         /* persistent_data */
       },
       { NULL, false, false }
    };
@@ -779,7 +779,7 @@ void retro_get_system_info(struct retro_system_info *info)
 #define _GIT_VERSION "-" GIT_VERSION
 #endif
    info->library_version = VERSION _GIT_VERSION;
-   info->valid_extensions = "bin|gen|smd|md|32x|cue|iso|chd|sms|m3u";
+   info->valid_extensions = "bin|gen|smd|md|32x|cue|iso|chd|sms|m3u|68k|sgd";
    info->need_fullpath = true;
 }
 


### PR DESCRIPTION
This PR adds the `Sega Mega Drive and Genesis Classics` ROM file types (`.68k` and `.sgd`) to the valid extensions list. These were previously added to the core info file without updating the core itself, leading to issues when loading content.