### PR TITLE
Fix accidental line remove in previous revert.

### DIFF
--- a/platform/libretro/libretro_core_options.h
+++ b/platform/libretro/libretro_core_options.h
@@ -262,6 +262,7 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "44100"
    },
+   { NULL, NULL, NULL, {{0}}, NULL },
 };
 
 /*


### PR DESCRIPTION
Should bring back the core option that were accidentally broken in the revert of #176