### PR TITLE
add HAVE_ARMv6 = 0 + minor fixes

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -498,13 +498,12 @@ else ifeq ($(platform), miyoo)
 	CC = /opt/miyoo/usr/bin/arm-linux-gcc
 	AR = /opt/miyoo/usr/bin/arm-linux-ar
 	SHARED := -shared -nostdlib
-        fpic := -fPIC
+	fpic := -fPIC
 	LIBM :=
 	DONT_COMPILE_IN_ZLIB = 1
 	CFLAGS += -fomit-frame-pointer -ffast-math -march=armv5te -mtune=arm926ej-s -D__GCW0__
-	CFLAGS += -DMIPS_USE_SYNCI
+	HAVE_ARMv6 = 0
 	LOW_MEMORY = 1
-	NO_ARM_ASM = 1
 
 # Windows MSVC 2017 all architectures
 else ifneq (,$(findstring windows_msvc2017,$(platform)))


### PR DESCRIPTION
PicoDrive's Arm cores building need HAVE_ARMv6 = 0 for Miyoo.