### PR TITLE
Use proper VFS version.

### DIFF
--- a/platform/libretro/libretro.c
+++ b/platform/libretro/libretro.c
@@ -644,7 +644,7 @@ void retro_set_environment(retro_environment_t cb)
          (void*)content_overrides);
 
 #ifdef USE_LIBRETRO_VFS
-   vfs_iface_info.required_interface_version = 1;
+   vfs_iface_info.required_interface_version = 2;
    vfs_iface_info.iface = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &vfs_iface_info))
       filestream_vfs_init(&vfs_iface_info);


### PR DESCRIPTION

VFS callbacks fail since it requires V2, which includes vfs_truncate. Otherwise it falls back to libretro-common code. Current VFS wrapping code in libretro-common needs V2 since vfs_truncate's callback is set.

https://github.com/libretro/libretro-common/blob/master/streams/file_stream.c#L65

Now VFS callbacks work properly in frontends that support them. Otherwise a hack of setting "cb->required_interface_version = 2" in frontend works. Only cores, according to specs, are meant to set the required version.