### PR TITLE
Fix build error on Windows

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -26,6 +26,9 @@ AS ?= as
 CC_AS ?= $(CC)
 CFLAGS ?=
 
+# Include root directory
+CFLAGS += -I$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
 #libretro includes
 CFLAGS += -I platform/libretro/libretro-common/include
 CFLAGS += -I platform/libretro/libretro-common/include/compat


### PR DESCRIPTION
## Description

This PR fixes a build error on Windows. The error is due to the root directory not explicitly added by the compiler.

## How has this been tested?

Before, error was:

```
  platform/common/mp3.c:11:10: fatal error: pico/pico_int.h: No such file or directory
     11 | #include <pico/pico_int.h>
        |          ^~~~~~~~~~~~~~~~~
```

After, the core builds successfully.

(I'm hunting down a link of our last successful CI run)