### PR TITLE
Propagate GIT_REVISION value to REVISION

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -44,7 +44,7 @@ LOW_MEMORY := 0
 TARGET_NAME := picodrive
 LIBM := -lm
 GIT_REVISION ?= -$(shell git rev-parse --short HEAD || echo unknown)
-
+CFLAGS += -DREVISION=\"$(GIT_REVISION)\"
 
 fpic :=
 


### PR DESCRIPTION
Small fix for version number showing up as "unknown", mentioned in https://github.com/libretro/RetroArch/issues/15800