### PR TITLE
Expose VRAM and CRAM on libretro to allow creation of debugger frontend

### DIFF
--- a/platform/libretro/libretro.c
+++ b/platform/libretro/libretro.c
@@ -1665,6 +1665,12 @@ void *retro_get_memory_data(unsigned type)
          else
             data = PicoMem.ram;
          break;
+      case RETRO_MEMORY_VIDEO_RAM:
+         data = PicoMem.vram;
+         break;
+      case 4:
+         data = PicoMem.cram;
+         break;
       default:
          data = NULL;
          break;
@@ -1704,6 +1710,15 @@ size_t retro_get_memory_size(unsigned type)
             return 0x2000;
          else
             return sizeof(PicoMem.ram);
+
+      case RETRO_MEMORY_VIDEO_RAM:
+            return sizeof(PicoMem.vram);
+         break;
+
+      // Libretro doens't have a constant declared for CRAM
+      case 4:
+            return sizeof(PicoMem.cram);
+         break;
 
       default:
          return 0;


### PR DESCRIPTION
This PR expose byte slice of Video Memory and Color Memory on libretro picodrive core
to allow creation of debugger frontends using libretro.

![image](https://github.com/libretro/picodrive/assets/3918305/0922c3e2-8125-4e66-8ce1-fb73342ee4b8)
