### PR TITLE
Try to fix emscripten build without breaking other builds

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -39,8 +39,8 @@ CFLAGS += -I platform/libretro/libretro-common/include/string
 CFLAGS += -I platform/libretro/libretro-common/include/vfs
 
 USE_LIBRETRO_VFS := 1
-STATIC_LINKING:= 1
-STATIC_LINKING_LINK:= 1
+STATIC_LINKING:= 0
+STATIC_LINKING_LINK:= 0
 LOW_MEMORY := 0
 TARGET_NAME := picodrive
 LIBM := -lm
@@ -437,7 +437,7 @@ else ifneq (,$(findstring armv,$(platform)))
 else ifeq ($(platform), emscripten) 
 	TARGET := $(TARGET_NAME)_libretro_$(platform).bc
 	ARCH = unknown
-
+	STATIC_LINKING_LINK = 1
 	STATIC_LINKING = 1
 
 # RS90


### PR DESCRIPTION
I made a mistake in a previous commit - the fix for emscripten should not be shared with all builds, just localized to the emscripten build.

Sorry for the noise.