### PR TITLE
Fix emscripten

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -443,6 +443,7 @@ else ifneq (,$(findstring armv,$(platform)))
 else ifeq ($(platform), emscripten) 
 	TARGET := $(TARGET_NAME)_libretro_$(platform).bc
 	ARCH = unknown
+	NO_ALIGN_FUNCTIONS = 1
 	STATIC_LINKING_LINK = 1
 	STATIC_LINKING = 1
 

--- a/cpu/cz80/cz80.c
+++ b/cpu/cz80/cz80.c
@@ -221,7 +221,7 @@ static inline unsigned char picodrive_read(unsigned short a)
 {
 	uptr v = z80_read_map[a >> Z80_MEM_SHIFT];
 	if (map_flag_set(v))
-		return ((z80_read_f *)(v << 1))(a);
+		return ((z80_read_f *)(map_to_function(v)))(a);
 	return *(unsigned char *)((v << 1) + a);
 }
 #endif

--- a/cpu/cz80/cz80macro.h
+++ b/cpu/cz80/cz80macro.h
@@ -67,7 +67,7 @@
 	unsigned char d = D; \
 	uptr v = z80_write_map[a >> Z80_MEM_SHIFT]; \
 	if (map_flag_set(v)) \
-		((z80_write_f *)(v << 1))(a, d); \
+		((z80_write_f *)(map_to_function(v)))(a, d); \
 	else \
 		*(unsigned char *)((v << 1) + a) = d; \
 }

--- a/pico/32x/memory.c
+++ b/pico/32x/memory.c
@@ -1928,7 +1928,7 @@ u32 REGPARM(2) p32x_sh2_read8(u32 a, SH2 *sh2)
   if (!map_flag_set(p))
     return *(s8 *)((p << 1) + MEM_BE2(a & sh2_map->mask));
   else
-    return ((sh2_read_handler *)(p << 1))(a, sh2);
+    return ((sh2_read_handler *)(map_to_function(p)))(a, sh2);
 }
 
 u32 REGPARM(2) p32x_sh2_read16(u32 a, SH2 *sh2)
@@ -1941,7 +1941,7 @@ u32 REGPARM(2) p32x_sh2_read16(u32 a, SH2 *sh2)
   if (!map_flag_set(p))
     return *(s16 *)((p << 1) + (a & sh2_map->mask));
   else
-    return ((sh2_read_handler *)(p << 1))(a, sh2);
+    return ((sh2_read_handler *)(map_to_function(p)))(a, sh2);
 }
 
 u32 REGPARM(2) p32x_sh2_read32(u32 a, SH2 *sh2)
@@ -1955,7 +1955,7 @@ u32 REGPARM(2) p32x_sh2_read32(u32 a, SH2 *sh2)
     u32 *pd = (u32 *)((p << 1) + (a & sh2_map->mask));
     return CPU_BE2(*pd);
   } else
-    return ((sh2_read_handler *)(p << 1))(a, sh2);
+    return ((sh2_read_handler *)(map_to_function(p)))(a, sh2);
 }
 
 void REGPARM(3) p32x_sh2_write8(u32 a, u32 d, SH2 *sh2)
@@ -2299,7 +2299,7 @@ static void get_bios(void)
 }
 
 #define MAP_MEMORY(m) ((uptr)(m) >> 1)
-#define MAP_HANDLER(h) ( ((uptr)(h) >> 1) | ((uptr)1 << (sizeof(uptr) * 8 - 1)) )
+#define MAP_HANDLER(h) ( ((uptr)(h) >> MAP_FUNCTION_SHIFT) | ((uptr)1 << (sizeof(uptr) * 8 - 1)) )
 
 static sh2_memmap msh2_read8_map[0x80], msh2_read16_map[0x80],  msh2_read32_map[0x80];
 static sh2_memmap ssh2_read8_map[0x80], ssh2_read16_map[0x80],  ssh2_read32_map[0x80];

--- a/pico/z80if.c
+++ b/pico/z80if.c
@@ -19,7 +19,7 @@ u32 z80_read(u32 a)
   a &= 0x00ffff;
   v = z80_read_map[a >> Z80_MEM_SHIFT];
   if (map_flag_set(v))
-    return ((z80_read_f *)(v << 1))(a);
+    return ((z80_read_f *)(map_to_function(v)))(a);
   else
     return *(u8 *)((v << 1) + a);
 }

--- a/platform/libretro/libretro-common/include/memmap.h
+++ b/platform/libretro/libretro-common/include/memmap.h
@@ -26,7 +26,7 @@
 #include <stdio.h>
 #include <stdint.h>
 
-#if defined(PSP) || defined(PS2) || defined(GEKKO) || defined(VITA) || defined(_XBOX) || defined(_3DS) || defined(WIIU) || defined(SWITCH) || defined(HAVE_LIBNX) || defined(__PS3__) || defined(__PSL1GHT__)
+#if defined(PSP) || defined(PS2) || defined(GEKKO) || defined(VITA) || defined(_XBOX) || defined(_3DS) || defined(WIIU) || defined(SWITCH) || defined(HAVE_LIBNX) || defined(__PS3__) || defined(__PSL1GHT__) || defined(__EMSCRIPTEN__)
 /* No mman available */
 #elif defined(_WIN32) && !defined(_XBOX)
 #include <windows.h>


### PR DESCRIPTION
This fixes #233
Emscripten (WASM) does not support align-functions at build time, and link-time alignment is WIP (https://github.com/llvm/llvm-project/pull/105532)

WASM is a "harvard architecture" - code is in a separate memory from data. All functions are stored in a table with no alignment (currently), so it should be safe to use the leftmost bit for the MAP_FLAG bit without first shifting right by 1 (unless we have 2^31 functions...).

This PR adds a `map_function_to_real` macro, which removes the MAP_FLAG bit on emscripten, but just shifts left by 1 bit on every other platform as before. `MAP_FUNCTION_SHIFT` is used when the tables are being built to determine how many bits to shift right (0 for emscripten, 1 for everything else).

Data pointers are still shifted right by 1 bit, since there's no problem with their alignment.

I have tested and confirmed that everything is working on emscripten as well as linux.

@irixxxx @ethanaobrien