### PR TITLE
Fix compiling to webOS / add to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,6 +102,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/emscripten-static.yml'
 
+  # webOS 32-bit (LGTV)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/webos-make.yml'
+
 # Stages for building
 stages:
   - build-prepare
@@ -277,4 +281,10 @@ libretro-build-miyoo-arm32:
 libretro-build-emscripten:
   extends:
     - .libretro-emscripten-static-retroarch-master
+    - .core-defs
+
+# webOS 32-bit
+libretro-build-webos-armv7a:
+  extends:
+    - .libretro-webos-armv7a-make-default
     - .core-defs

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -615,6 +615,12 @@ else
 
 endif
 
+ifneq (,$(findstring webos,$(CROSS_COMPILE)$(findstring starfish,$(CROSS_COMPILE))))
+  CFLAGS += -DWEBOS
+  CYCLONE_CC ?= $(CC_FOR_BUILD)
+  CYCLONE_CXX ?= $(CXX_FOR_BUILD)
+endif
+
 CFLAGS += -D__LIBRETRO__
 
 ifeq ($(USE_LIBRETRO_VFS),1)

--- a/platform/common/mp3_drmp3.c
+++ b/platform/common/mp3_drmp3.c
@@ -20,6 +20,9 @@
 #define mp3dec_decode _mp3dec_decode
 #define mp3dec_start _mp3dec_start
 #endif
+#ifdef WEBOS
+#define fopen64 fopen
+#endif
 #define DR_MP3_IMPLEMENTATION
 #include "dr_libs/dr_mp3.h"
 #include "mp3.h"


### PR DESCRIPTION
Currently fails to build due an issue with dr_mp3

```
platform/common/dr_libs/dr_mp3.h: In function ‘drmp3_fopen’:
platform/common/dr_libs/dr_mp3.h:3362:17: error: assignment to ‘RFILE *’ from incompatible pointer type ‘FILE *’ [-Wincompatible-pointer-types]
 3362 |         *ppFile = fopen64(pFilePath, pOpenMode);
```

So switched to MP3 helix (as it is ARM).. :+1: 