### PR TITLE
cyclone: make use of quotes when using spaces in cyclone_cc e.g. when using ccache / update webOS section in Makefile.libretro

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -617,8 +617,6 @@ endif
 
 ifneq (,$(findstring webos,$(CROSS_COMPILE)$(findstring starfish,$(CROSS_COMPILE))))
   CFLAGS += -DWEBOS
-  CYCLONE_CC ?= $(CC_FOR_BUILD)
-  CYCLONE_CXX ?= $(CXX_FOR_BUILD)
 endif
 
 CFLAGS += -D__LIBRETRO__

--- a/platform/common/common.mak
+++ b/platform/common/common.mak
@@ -201,7 +201,7 @@ $(FR)cpu/cyclone/Cyclone.h:
 
 $(FR)cpu/cyclone/Cyclone.s: $(FR)cpu/$(CYCLONE_CONFIG)
 	@echo building Cyclone...
-	@export CC=$(CYCLONE_CC) CXX=$(CYCLONE_CXX) CFLAGS=-O2 CXXFLAGS=-O2 CPPFLAGS="" LDFLAGS="" && \
+	@export CC="$(CYCLONE_CC)" CXX="$(CYCLONE_CXX)" CFLAGS=-O2 CXXFLAGS=-O2 CPPFLAGS="" LDFLAGS="" && \
 		make -C $(R)cpu/cyclone/ CONFIG_FILE=../$(CYCLONE_CONFIG) HAVE_ARMv6=$(HAVE_ARMv6)
 
 $(FR)cpu/cyclone/Cyclone.s: $(FR)cpu/cyclone/*.cpp $(FR)cpu/cyclone/*.h


### PR DESCRIPTION
This fixes an issue when using ccache as part of CC_FOR_BUILD which is specified in the toolchain.

Error when compiling on gitlab:

https://git.libretro.com/libretro/picodrive/-/jobs/1197152:
```
building Cyclone...
/bin/sh: 1: export: /usr/local/bin/gcc: bad variable name
```

The space between ccache and gcc means we need to quote around them:

```
CC_FOR_BUILD="ccache /usr/bin/gcc"
CXX_FOR_BUILD="ccache /usr/bin/g++"
```

when used in common.mak

