### PR TITLE
ci: add Linux aarch64 libretro build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
     
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+    
   # Linux 32-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
@@ -133,6 +137,12 @@ libretro-build-windows-i686:
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # Linux 32-bit


### PR DESCRIPTION
The buildbot publishes `picodrive_libretro.so` for linux/x86_64 and linux/x86, but there is no desktop Linux ARM64 build — `.gitlab-ci.yml` has no aarch64 job, so nothing is ever produced for that platform.

This adds the `/linux-aarch64.yml` template include and a `libretro-build-linux-aarch64` job, mirroring the existing x64 one. Same shape dozens of cores already use, and no image or compiler override is needed: the `libretro-build-aarch64-ubuntu` image installs gcc-12/g++-12 and points `gcc`/`g++` at them via `update-alternatives`.

**Verified on real aarch64 hardware, not just proposed:**

- Builds clean from this branch: `make -f Makefile.libretro platform=unix` produces `picodrive_libretro.so`, with `-DDRC_SH2` active (the SH2 dynarec, ARM64 backend).
- The resulting core actually runs. Driven through a minimal libretro front end, it reports `PicoDrive 2.05`, negotiates RGB565, loads content, and renders 300 frames at 320x224, then unloads and deinitialises cleanly.
- The frame content is right, not merely non-empty: the test ROM writes `0x0EEE` to CRAM entry 0 and loops, and every pixel of the output comes back as `0xEF5D` in RGB565 — R=29, G=58, B=29, i.e. the ~(233,235,233) that palette entry encodes. So the 68000 core, the VDP register writes and the palette path all executed correctly in the aarch64 build.

Only the Linux ARM64 job is added; nothing else in the file changes (the diff keeps the file's CRLF line endings).