### PR TITLE
libretro: remove mwup from wiiu and add __wiiu__

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -300,7 +300,7 @@ else ifeq ($(platform), wiiu)
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-	CFLAGS += -DGEKKO -DWIIU -DHW_RVL -DHW_WUP -mwup -mcpu=750 -meabi -mhard-float
+	CFLAGS += -DGEKKO -DWIIU -DHW_RVL -DHW_WUP -D__wiiu__ -mcpu=750 -meabi -mhard-float
 	PLATFORM_TREMOR ?= 1
 	STATIC_LINKING = 1
 	STATIC_LINKING_LINK = 1


### PR DESCRIPTION
mwup was removed from the devkitpro wiiu toolchain from v34 and above and no longer compiles with it.

I have upgraded the wiiu toolchain on the buildbot.